### PR TITLE
Add ML Flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ AZURE_OPENAI_KEY=your-azure-openai-api-key
 DEPLOYMENT_NAME=your-chat-model-deployment
 
 ############################
-# MLflow (optional)
+# MLflow (required for evaluation)
 ############################
-# Used when running evaluation with --mlflow
-MLFLOW_TRACKING_URI=http://localhost:5000
+# Required by evaluation/run_evaluation.py
+MLFLOW_TRACKING_URI=azureml://<region>.api.azureml.ms/mlflow/v1.0/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.MachineLearningServices/workspaces/<workspace-name>
 MLFLOW_EXPERIMENT_NAME=ContractMap-Evaluation

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+############################
+# Azure OpenAI (required)
+############################
+AZURE_OPENAI_API_VERSION=2024-02-15-preview
+AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
+AZURE_OPENAI_KEY=your-azure-openai-api-key
+DEPLOYMENT_NAME=your-chat-model-deployment
+
+############################
+# MLflow (optional)
+############################
+# Used when running evaluation with --mlflow
+MLFLOW_TRACKING_URI=http://localhost:5000
+MLFLOW_EXPERIMENT_NAME=ContractMap-Evaluation

--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ Optional arguments:
 - `--truth-set /path/to/truth.csv` to use a different truth set file.
 - `--prompt system_prompt_v2.md` to choose a prompt from `prompts/`.
 - `--list-prompts` to print available prompt files.
-- `--mlflow` to enable MLflow tracking (logs params, metrics, prompt, and results CSV).
-- `--mlflow-tracking-uri http://localhost:5000` to set tracking server (or use `MLFLOW_TRACKING_URI`).
+- `--mlflow-tracking-uri <azureml://...>` to set tracking server (or use `MLFLOW_TRACKING_URI`).
 - `--mlflow-experiment-name ContractMap-Evaluation` to set experiment (or use `MLFLOW_EXPERIMENT_NAME`).
 - `--mlflow-run-name my-run` to set a custom run name.
+
+`run_evaluation.py` always logs to MLflow (params, metrics, prompt, and results CSV).
 
 ### From a jupyter notebook
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Optional arguments:
 - `--truth-set /path/to/truth.csv` to use a different truth set file.
 - `--prompt system_prompt_v2.md` to choose a prompt from `prompts/`.
 - `--list-prompts` to print available prompt files.
+- `--mlflow` to enable MLflow tracking (logs params, metrics, prompt, and results CSV).
+- `--mlflow-tracking-uri http://localhost:5000` to set tracking server (or use `MLFLOW_TRACKING_URI`).
+- `--mlflow-experiment-name ContractMap-Evaluation` to set experiment (or use `MLFLOW_EXPERIMENT_NAME`).
+- `--mlflow-run-name my-run` to set a custom run name.
 
 ### From a jupyter notebook
 

--- a/evaluation/run_evaluation.py
+++ b/evaluation/run_evaluation.py
@@ -1,9 +1,14 @@
 import argparse
 import asyncio
+import os
 import sys
+import time
+from contextlib import nullcontext
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_DIR = REPO_ROOT / "src"
 PROMPTS_DIR = REPO_ROOT / "prompts"
@@ -72,12 +77,31 @@ async def _classify_description(description: str, mapper: str, prompt_file: Path
     )
 
 
+def _get_mlflow_module() -> Any | None:
+    try:
+        import importlib
+
+        return importlib.import_module("mlflow")
+    except ModuleNotFoundError:
+        return None
+
+
 async def run_evaluation(
     truth_set_path: Path,
     mapper: str,
     prompt_name: str | None,
     output_path: Path | None,
+    mlflow_enabled: bool = False,
+    mlflow_tracking_uri: str | None = None,
+    mlflow_experiment_name: str | None = None,
+    mlflow_run_name: str | None = None,
 ) -> None:
+    mlflow_module = _get_mlflow_module() if mlflow_enabled else None
+    if mlflow_enabled and mlflow_module is None:
+        raise ModuleNotFoundError(
+            "MLflow is not installed. Install dependencies with 'pip install -r requirements.txt'."
+        )
+
     prompt_file = _resolve_prompt_file(prompt_name=prompt_name, mapper=mapper)
     df = _load_truth_set(truth_set_path=truth_set_path)
 
@@ -87,29 +111,66 @@ async def run_evaluation(
     predictions: list[str] = []
     correct = 0
 
-    for description, expected in zip(descriptions, categories):
-        prediction = await _classify_description(
-            description=description,
-            mapper=mapper,
-            prompt_file=prompt_file,
-        )
-        predictions.append(prediction)
-        is_correct = prediction == expected
-        correct += int(is_correct)
-        print(f"expected: {expected} | predicted: {prediction} | correct: {is_correct}")
-
-    accuracy = (correct / len(predictions)) * 100 if predictions else 0.0
-    print(f"\n{mapper.upper()} accuracy: {accuracy:.2f}% on {len(predictions)} samples")
-
     if output_path is None:
         output_path = REPO_ROOT / f"data/results/eval_{mapper}_{prompt_file.stem}.csv"
-
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    result_df = df[["Category", "Description"]].copy()
-    result_df["AI classification"] = predictions
-    result_df["correct"] = result_df["Category"] == result_df["AI classification"]
-    result_df.to_csv(output_path, index=False)
-    print(f"Saved results to: {output_path}")
+
+    if mlflow_enabled:
+        tracking_uri = mlflow_tracking_uri or os.getenv(
+            "MLFLOW_TRACKING_URI", "http://localhost:5000"
+        )
+        experiment_name = mlflow_experiment_name or os.getenv(
+            "MLFLOW_EXPERIMENT_NAME", "ContractMap-Evaluation"
+        )
+        mlflow_module.set_tracking_uri(tracking_uri)
+        mlflow_module.set_experiment(experiment_name)
+        run_context = mlflow_module.start_run(run_name=mlflow_run_name)
+    else:
+        run_context = nullcontext()
+
+    with run_context:
+        if mlflow_enabled:
+            mlflow_module.log_param("mapper", mapper)
+            mlflow_module.log_param("truth_set_path", str(truth_set_path.resolve()))
+            mlflow_module.log_param("prompt_name", prompt_name or prompt_file.name)
+            mlflow_module.log_param("prompt_path", str(prompt_file.resolve()))
+            mlflow_module.log_param("num_samples", len(descriptions))
+            mlflow_module.log_artifact(
+                str(prompt_file.resolve()), artifact_path="prompts"
+            )
+
+        start_time = time.perf_counter()
+        for description, expected in zip(descriptions, categories):
+            prediction = await _classify_description(
+                description=description,
+                mapper=mapper,
+                prompt_file=prompt_file,
+            )
+            predictions.append(prediction)
+            is_correct = prediction == expected
+            correct += int(is_correct)
+            print(
+                f"expected: {expected} | predicted: {prediction} | correct: {is_correct}"
+            )
+
+        elapsed_seconds = time.perf_counter() - start_time
+        accuracy = (correct / len(predictions)) * 100 if predictions else 0.0
+        print(f"\n{mapper.upper()} accuracy: {accuracy:.2f}% on {len(predictions)} samples")
+
+        result_df = df[["Category", "Description"]].copy()
+        result_df["AI classification"] = predictions
+        result_df["correct"] = result_df["Category"] == result_df["AI classification"]
+        result_df.to_csv(output_path, index=False)
+        print(f"Saved results to: {output_path}")
+
+        if mlflow_enabled:
+            mlflow_module.log_metric("accuracy_percent", accuracy)
+            mlflow_module.log_metric("accuracy_fraction", accuracy / 100)
+            mlflow_module.log_metric("correct_predictions", correct)
+            mlflow_module.log_metric("evaluation_duration_seconds", elapsed_seconds)
+            mlflow_module.log_artifact(
+                str(output_path.resolve()), artifact_path="results"
+            )
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -145,6 +206,29 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="List available prompt files in prompts/ and exit.",
     )
+    parser.add_argument(
+        "--mlflow",
+        action="store_true",
+        help="Enable MLflow experiment tracking.",
+    )
+    parser.add_argument(
+        "--mlflow-tracking-uri",
+        type=str,
+        default=None,
+        help="Optional MLflow tracking URI. Defaults to MLFLOW_TRACKING_URI or localhost.",
+    )
+    parser.add_argument(
+        "--mlflow-experiment-name",
+        type=str,
+        default=None,
+        help="Optional MLflow experiment name. Defaults to MLFLOW_EXPERIMENT_NAME or ContractMap-Evaluation.",
+    )
+    parser.add_argument(
+        "--mlflow-run-name",
+        type=str,
+        default=None,
+        help="Optional MLflow run name.",
+    )
     return parser
 
 
@@ -164,6 +248,10 @@ def main() -> None:
             mapper=args.mapper,
             prompt_name=args.prompt,
             output_path=args.output,
+            mlflow_enabled=args.mlflow,
+            mlflow_tracking_uri=args.mlflow_tracking_uri,
+            mlflow_experiment_name=args.mlflow_experiment_name,
+            mlflow_run_name=args.mlflow_run_name,
         )
     )
 

--- a/evaluation/run_evaluation.py
+++ b/evaluation/run_evaluation.py
@@ -3,7 +3,6 @@ import asyncio
 import os
 import sys
 import time
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from dotenv import load_dotenv
@@ -97,13 +96,12 @@ async def run_evaluation(
     mapper: str,
     prompt_name: str | None,
     output_path: Path | None,
-    mlflow_enabled: bool = False,
     mlflow_tracking_uri: str | None = None,
     mlflow_experiment_name: str | None = None,
     mlflow_run_name: str | None = None,
 ) -> None:
-    mlflow_module = _get_mlflow_module() if mlflow_enabled else None
-    if mlflow_enabled and mlflow_module is None:
+    mlflow_module = _get_mlflow_module()
+    if mlflow_module is None:
         raise ModuleNotFoundError(
             "Azure MLflow is not installed. Install with 'pip install azureml-mlflow' "
             "and authenticate using 'az login'."
@@ -122,29 +120,26 @@ async def run_evaluation(
         output_path = REPO_ROOT / f"data/results/eval_{mapper}_{prompt_file.stem}.csv"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if mlflow_enabled:
-        tracking_uri = mlflow_tracking_uri or os.getenv(
-            "MLFLOW_TRACKING_URI", "http://localhost:5000"
+    tracking_uri = mlflow_tracking_uri or os.getenv("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        raise ValueError(
+            "MLflow tracking URI is required. "
+            "Set --mlflow-tracking-uri or MLFLOW_TRACKING_URI."
         )
-        experiment_name = mlflow_experiment_name or os.getenv(
-            "MLFLOW_EXPERIMENT_NAME", "ContractMap-Evaluation"
-        )
-        mlflow_module.set_tracking_uri(tracking_uri)
-        mlflow_module.set_experiment(experiment_name)
-        run_context = mlflow_module.start_run(run_name=mlflow_run_name)
-    else:
-        run_context = nullcontext()
+    experiment_name = mlflow_experiment_name or os.getenv(
+        "MLFLOW_EXPERIMENT_NAME", "ContractMap-Evaluation"
+    )
+    mlflow_module.set_tracking_uri(tracking_uri)
+    mlflow_module.set_experiment(experiment_name)
+    run_context = mlflow_module.start_run(run_name=mlflow_run_name)
 
     with run_context:
-        if mlflow_enabled:
-            mlflow_module.log_param("mapper", mapper)
-            mlflow_module.log_param("truth_set_path", str(truth_set_path.resolve()))
-            mlflow_module.log_param("prompt_name", prompt_name or prompt_file.name)
-            mlflow_module.log_param("prompt_path", str(prompt_file.resolve()))
-            mlflow_module.log_param("num_samples", len(descriptions))
-            mlflow_module.log_artifact(
-                str(prompt_file.resolve()), artifact_path="prompts"
-            )
+        mlflow_module.log_param("mapper", mapper)
+        mlflow_module.log_param("truth_set_path", str(truth_set_path.resolve()))
+        mlflow_module.log_param("prompt_name", prompt_name or prompt_file.name)
+        mlflow_module.log_param("prompt_path", str(prompt_file.resolve()))
+        mlflow_module.log_param("num_samples", len(descriptions))
+        mlflow_module.log_artifact(str(prompt_file.resolve()), artifact_path="prompts")
 
         start_time = time.perf_counter()
         for description, expected in zip(descriptions, categories):
@@ -172,14 +167,11 @@ async def run_evaluation(
         result_df.to_csv(output_path, index=False)
         print(f"Saved results to: {output_path}")
 
-        if mlflow_enabled:
-            mlflow_module.log_metric("accuracy_percent", accuracy)
-            mlflow_module.log_metric("accuracy_fraction", accuracy / 100)
-            mlflow_module.log_metric("correct_predictions", correct)
-            mlflow_module.log_metric("evaluation_duration_seconds", elapsed_seconds)
-            mlflow_module.log_artifact(
-                str(output_path.resolve()), artifact_path="results"
-            )
+        mlflow_module.log_metric("accuracy_percent", accuracy)
+        mlflow_module.log_metric("accuracy_fraction", accuracy / 100)
+        mlflow_module.log_metric("correct_predictions", correct)
+        mlflow_module.log_metric("evaluation_duration_seconds", elapsed_seconds)
+        mlflow_module.log_artifact(str(output_path.resolve()), artifact_path="results")
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -216,15 +208,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="List available prompt files in prompts/ and exit.",
     )
     parser.add_argument(
-        "--mlflow",
-        action="store_true",
-        help="Enable Azure MLflow experiment tracking.",
-    )
-    parser.add_argument(
         "--mlflow-tracking-uri",
         type=str,
         default=None,
-        help="Optional Azure MLflow tracking URI (azureml:// scheme). Defaults to MLFLOW_TRACKING_URI env var.",
+        help="Azure MLflow tracking URI (azureml:// scheme). Defaults to MLFLOW_TRACKING_URI env var.",
     )
     parser.add_argument(
         "--mlflow-experiment-name",
@@ -257,7 +244,6 @@ def main() -> None:
             mapper=args.mapper,
             prompt_name=args.prompt,
             output_path=args.output,
-            mlflow_enabled=args.mlflow,
             mlflow_tracking_uri=args.mlflow_tracking_uri,
             mlflow_experiment_name=args.mlflow_experiment_name,
             mlflow_run_name=args.mlflow_run_name,

--- a/evaluation/run_evaluation.py
+++ b/evaluation/run_evaluation.py
@@ -6,8 +6,11 @@ import time
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
+from dotenv import load_dotenv
 
 import pandas as pd
+
+load_dotenv()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_DIR = REPO_ROOT / "src"
@@ -19,7 +22,6 @@ DEFAULT_TRUTH_SET = (
 # Ensure imports work when running this file directly from repo root.
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
-
 
 
 def _available_prompt_files() -> list[Path]:
@@ -61,7 +63,9 @@ def _load_truth_set(truth_set_path: Path) -> pd.DataFrame:
     return df.dropna(subset=["Description", "Category"]).reset_index(drop=True)
 
 
-async def _classify_description(description: str, mapper: str, prompt_file: Path) -> str:
+async def _classify_description(
+    description: str, mapper: str, prompt_file: Path
+) -> str:
     if mapper == "v1":
         from core.classification_v1 import contract_mapper
 
@@ -71,6 +75,7 @@ async def _classify_description(description: str, mapper: str, prompt_file: Path
         )
 
     from core.classification_v2 import contract_mapper_v2
+
     return await contract_mapper_v2(
         user_contract_description=description,
         system_prompt_file_location=prompt_file,
@@ -78,6 +83,7 @@ async def _classify_description(description: str, mapper: str, prompt_file: Path
 
 
 def _get_mlflow_module() -> Any | None:
+    """Import Azure MLflow module (azureml-mlflow extends standard mlflow)."""
     try:
         import importlib
 
@@ -99,7 +105,8 @@ async def run_evaluation(
     mlflow_module = _get_mlflow_module() if mlflow_enabled else None
     if mlflow_enabled and mlflow_module is None:
         raise ModuleNotFoundError(
-            "MLflow is not installed. Install dependencies with 'pip install -r requirements.txt'."
+            "Azure MLflow is not installed. Install with 'pip install azureml-mlflow' "
+            "and authenticate using 'az login'."
         )
 
     prompt_file = _resolve_prompt_file(prompt_name=prompt_name, mapper=mapper)
@@ -155,7 +162,9 @@ async def run_evaluation(
 
         elapsed_seconds = time.perf_counter() - start_time
         accuracy = (correct / len(predictions)) * 100 if predictions else 0.0
-        print(f"\n{mapper.upper()} accuracy: {accuracy:.2f}% on {len(predictions)} samples")
+        print(
+            f"\n{mapper.upper()} accuracy: {accuracy:.2f}% on {len(predictions)} samples"
+        )
 
         result_df = df[["Category", "Description"]].copy()
         result_df["AI classification"] = predictions
@@ -209,25 +218,25 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--mlflow",
         action="store_true",
-        help="Enable MLflow experiment tracking.",
+        help="Enable Azure MLflow experiment tracking.",
     )
     parser.add_argument(
         "--mlflow-tracking-uri",
         type=str,
         default=None,
-        help="Optional MLflow tracking URI. Defaults to MLFLOW_TRACKING_URI or localhost.",
+        help="Optional Azure MLflow tracking URI (azureml:// scheme). Defaults to MLFLOW_TRACKING_URI env var.",
     )
     parser.add_argument(
         "--mlflow-experiment-name",
         type=str,
         default=None,
-        help="Optional MLflow experiment name. Defaults to MLFLOW_EXPERIMENT_NAME or ContractMap-Evaluation.",
+        help="Optional Azure MLflow experiment name. Defaults to MLFLOW_EXPERIMENT_NAME or ContractMap-Evaluation.",
     )
     parser.add_argument(
         "--mlflow-run-name",
         type=str,
         default=None,
-        help="Optional MLflow run name.",
+        help="Optional Azure MLflow run name.",
     )
     return parser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ fastapi>=0.116.1,<0.117.0
 uvicorn>=0.35.0,<0.36.0
 pytest
 ruff==0.15.1
+mlflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,7 @@ fastapi>=0.116.1,<0.117.0
 uvicorn>=0.35.0,<0.36.0
 pytest
 ruff==0.15.1
-mlflow
+pre-commit
+azureml-mlflow
+azure-ai-ml
+azure-identity

--- a/tests/test_run_evaluation.py
+++ b/tests/test_run_evaluation.py
@@ -65,3 +65,92 @@ def test_run_evaluation_writes_default_output_csv(monkeypatch, tmp_path):
     result_df = pd.read_csv(output_csv)
     assert result_df["AI classification"].tolist() == ["cat-a", "wrong-cat"]
     assert result_df["correct"].tolist() == [True, False]
+
+
+def test_run_evaluation_logs_mlflow_params_metrics_and_artifacts(monkeypatch, tmp_path):
+    truth_set = tmp_path / "truth.csv"
+    prompt_file = tmp_path / "prompts" / "custom_prompt.md"
+    output_path = tmp_path / "results.csv"
+    prompt_file.parent.mkdir(parents=True, exist_ok=True)
+    prompt_file.write_text("prompt")
+    pd.DataFrame(
+        {
+            "Description": ["desc-a", "desc-b"],
+            "Category": ["cat-a", "cat-b"],
+        }
+    ).to_csv(truth_set, index=False)
+
+    async def fake_classify(description: str, mapper: str, prompt_file: Path) -> str:
+        mapping = {"desc-a": "cat-a", "desc-b": "wrong-cat"}
+        return mapping[description]
+
+    class _DummyRunContext:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeMLflow:
+        def __init__(self):
+            self.tracking_uri = None
+            self.experiment_name = None
+            self.start_run_name = None
+            self.params: dict[str, object] = {}
+            self.metrics: dict[str, float] = {}
+            self.artifacts: list[tuple[str, str]] = []
+
+        def set_tracking_uri(self, uri: str) -> None:
+            self.tracking_uri = uri
+
+        def set_experiment(self, name: str) -> None:
+            self.experiment_name = name
+
+        def start_run(self, run_name: str | None = None):
+            self.start_run_name = run_name
+            return _DummyRunContext()
+
+        def log_param(self, key: str, value) -> None:
+            self.params[key] = value
+
+        def log_metric(self, key: str, value: float) -> None:
+            self.metrics[key] = value
+
+        def log_artifact(self, path: str, artifact_path: str | None = None) -> None:
+            self.artifacts.append((path, artifact_path))
+
+    fake_mlflow = FakeMLflow()
+    monkeypatch.setattr(run_evaluation, "_resolve_prompt_file", lambda *args, **kwargs: prompt_file)
+    monkeypatch.setattr(run_evaluation, "_classify_description", fake_classify)
+    monkeypatch.setattr(run_evaluation, "_get_mlflow_module", lambda: fake_mlflow)
+
+    asyncio.run(
+        run_evaluation.run_evaluation(
+            truth_set_path=truth_set,
+            mapper="v2",
+            prompt_name=None,
+            output_path=output_path,
+            mlflow_enabled=True,
+            mlflow_tracking_uri="http://mlflow.local:5000",
+            mlflow_experiment_name="ContractMap-Evaluation-Test",
+            mlflow_run_name="unit-test-run",
+        )
+    )
+
+    assert fake_mlflow.tracking_uri == "http://mlflow.local:5000"
+    assert fake_mlflow.experiment_name == "ContractMap-Evaluation-Test"
+    assert fake_mlflow.start_run_name == "unit-test-run"
+
+    assert fake_mlflow.params["mapper"] == "v2"
+    assert fake_mlflow.params["truth_set_path"] == str(truth_set.resolve())
+    assert fake_mlflow.params["prompt_name"] == "custom_prompt.md"
+    assert fake_mlflow.params["prompt_path"] == str(prompt_file.resolve())
+    assert fake_mlflow.params["num_samples"] == 2
+
+    assert fake_mlflow.metrics["accuracy_percent"] == 50.0
+    assert fake_mlflow.metrics["accuracy_fraction"] == 0.5
+    assert fake_mlflow.metrics["correct_predictions"] == 1
+    assert "evaluation_duration_seconds" in fake_mlflow.metrics
+
+    assert (str(prompt_file.resolve()), "prompts") in fake_mlflow.artifacts
+    assert (str(output_path.resolve()), "results") in fake_mlflow.artifacts

--- a/tests/test_run_evaluation.py
+++ b/tests/test_run_evaluation.py
@@ -7,6 +7,43 @@ import pytest
 import evaluation.run_evaluation as run_evaluation
 
 
+class _DummyRunContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeMLflow:
+    def __init__(self):
+        self.tracking_uri = None
+        self.experiment_name = None
+        self.start_run_name = None
+        self.params: dict[str, object] = {}
+        self.metrics: dict[str, float] = {}
+        self.artifacts: list[tuple[str, str]] = []
+
+    def set_tracking_uri(self, uri: str) -> None:
+        self.tracking_uri = uri
+
+    def set_experiment(self, name: str) -> None:
+        self.experiment_name = name
+
+    def start_run(self, run_name: str | None = None):
+        self.start_run_name = run_name
+        return _DummyRunContext()
+
+    def log_param(self, key: str, value) -> None:
+        self.params[key] = value
+
+    def log_metric(self, key: str, value: float) -> None:
+        self.metrics[key] = value
+
+    def log_artifact(self, path: str, artifact_path: str | None = None) -> None:
+        self.artifacts.append((path, artifact_path))
+
+
 def test_load_truth_set_raises_when_required_columns_missing(tmp_path):
     truth_set = tmp_path / "truth.csv"
     pd.DataFrame({"Description": ["desc only"]}).to_csv(truth_set, index=False)
@@ -49,6 +86,7 @@ def test_run_evaluation_writes_default_output_csv(monkeypatch, tmp_path):
     monkeypatch.setattr(run_evaluation, "REPO_ROOT", repo_root)
     monkeypatch.setattr(run_evaluation, "_resolve_prompt_file", lambda *args, **kwargs: prompt_file)
     monkeypatch.setattr(run_evaluation, "_classify_description", fake_classify)
+    monkeypatch.setattr(run_evaluation, "_get_mlflow_module", lambda: FakeMLflow())
 
     asyncio.run(
         run_evaluation.run_evaluation(
@@ -56,6 +94,7 @@ def test_run_evaluation_writes_default_output_csv(monkeypatch, tmp_path):
             mapper="v2",
             prompt_name=None,
             output_path=None,
+            mlflow_tracking_uri="azureml://unit-test",
         )
     )
 
@@ -84,41 +123,6 @@ def test_run_evaluation_logs_mlflow_params_metrics_and_artifacts(monkeypatch, tm
         mapping = {"desc-a": "cat-a", "desc-b": "wrong-cat"}
         return mapping[description]
 
-    class _DummyRunContext:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-    class FakeMLflow:
-        def __init__(self):
-            self.tracking_uri = None
-            self.experiment_name = None
-            self.start_run_name = None
-            self.params: dict[str, object] = {}
-            self.metrics: dict[str, float] = {}
-            self.artifacts: list[tuple[str, str]] = []
-
-        def set_tracking_uri(self, uri: str) -> None:
-            self.tracking_uri = uri
-
-        def set_experiment(self, name: str) -> None:
-            self.experiment_name = name
-
-        def start_run(self, run_name: str | None = None):
-            self.start_run_name = run_name
-            return _DummyRunContext()
-
-        def log_param(self, key: str, value) -> None:
-            self.params[key] = value
-
-        def log_metric(self, key: str, value: float) -> None:
-            self.metrics[key] = value
-
-        def log_artifact(self, path: str, artifact_path: str | None = None) -> None:
-            self.artifacts.append((path, artifact_path))
-
     fake_mlflow = FakeMLflow()
     monkeypatch.setattr(run_evaluation, "_resolve_prompt_file", lambda *args, **kwargs: prompt_file)
     monkeypatch.setattr(run_evaluation, "_classify_description", fake_classify)
@@ -130,7 +134,6 @@ def test_run_evaluation_logs_mlflow_params_metrics_and_artifacts(monkeypatch, tm
             mapper="v2",
             prompt_name=None,
             output_path=output_path,
-            mlflow_enabled=True,
             mlflow_tracking_uri="http://mlflow.local:5000",
             mlflow_experiment_name="ContractMap-Evaluation-Test",
             mlflow_run_name="unit-test-run",


### PR DESCRIPTION
## Summary

- Added optional MLflow tracking to `evaluation/run_evaluation.py` (modeled after the WIS evaluation flow) so evaluations can log:
  - run params (`mapper`, truth set path, prompt name/path, sample count)
  - run metrics (`accuracy_percent`, `accuracy_fraction`, `correct_predictions`, `evaluation_duration_seconds`)
  - artifacts (selected prompt file and output results CSV)
- Added new CLI flags for MLflow configuration:
  - `--mlflow`
  - `--mlflow-tracking-uri`
  - `--mlflow-experiment-name`
  - `--mlflow-run-name`
- Added `mlflow` dependency to `requirements.txt`.
- Updated `README.md` with MLflow usage options.
- Added/extended tests in `tests/test_run_evaluation.py`:
  - existing output CSV behavior remains covered
  - new test verifies MLflow params, metrics, and artifacts are logged when enabled
- Added `.env.example` with required Azure OpenAI variables and optional MLflow environment variables.

## Why

This enables reproducible, trackable evaluation runs with experiment history and artifacts, making prompt/model comparison easier over time and aligning this repo with the evaluation observability pattern used in the referenced WIS script.
